### PR TITLE
Drop useless validation constraint

### DIFF
--- a/src/Vehicle/Manage/Add/Contract/AddVehicle.php
+++ b/src/Vehicle/Manage/Add/Contract/AddVehicle.php
@@ -47,7 +47,6 @@ final class AddVehicle
      * Year of release
      *
      * @Assert\NotBlank(message="Year of release must be specified")
-     * @Assert\Type("integer", message="Wrong year")
      *
      * @var int
      */


### PR DESCRIPTION
Always valid because of constructor argument typehint